### PR TITLE
fix(usability): Disable shift causing edit

### DIFF
--- a/src/features/edit/js/gridEdit.js
+++ b/src/features/edit/js/gridEdit.js
@@ -259,6 +259,8 @@
           if (evt.keyCode === uiGridConstants.keymap.LEFT ||
             (evt.keyCode === uiGridConstants.keymap.TAB && evt.shiftKey) ||
 
+            evt.keyCode === uiGridConstants.keymap.SHIFT ||
+
             evt.keyCode === uiGridConstants.keymap.RIGHT ||
             evt.keyCode === uiGridConstants.keymap.TAB ||
 


### PR DESCRIPTION
Prevent Shift key press from triggering edit mode

@jonathanchris : Closes b2io/OrderBuilder#401
